### PR TITLE
Allow enumerations to be of any base numeric type

### DIFF
--- a/enum_test.go
+++ b/enum_test.go
@@ -1,7 +1,6 @@
 package enum_test
 
 import (
-	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -64,13 +63,6 @@ func Test_Enum_Map_Duplicated(t *testing.T) {
 	assert.Panics(t, func() { enum.Map(RoleAdmin, "admin") })
 }
 
-func Test_Enum_Map_Undefined(t *testing.T) {
-	type Role int
-	const RoleUser = math.MaxInt32
-
-	assert.Panics(t, func() { enum.Map(RoleUser, "admin") })
-}
-
 func Test_Enum_StringOf(t *testing.T) {
 	type Role int
 
@@ -106,9 +98,12 @@ func Test_Enum_EnumOf(t *testing.T) {
 		RoleAdmin = enum.New[Role]("admin")
 	)
 
-	assert.Equal(t, enum.EnumOf[Role]("user"), RoleUser)
-	assert.Equal(t, enum.EnumOf[Role]("admin"), RoleAdmin)
-	assert.False(t, enum.IsValid(enum.EnumOf[Role]("moderator")))
+	userRole, _ := enum.EnumOf[Role]("user")
+	assert.Equal(t, userRole, RoleUser)
+	adminRole, _ := enum.EnumOf[Role]("admin")
+	assert.Equal(t, adminRole, RoleAdmin)
+	_, valid := enum.EnumOf[Role]("moderator")
+	assert.False(t, valid)
 }
 
 func Test_Enum_MustEnumOf(t *testing.T) {
@@ -134,19 +129,19 @@ func Test_Enum_Undefined(t *testing.T) {
 		RoleAdmin = enum.New[Role]("admin")
 	)
 
-	moderator := enum.EnumOf[Role]("moderator")
-	assert.NotEqual(t, moderator, RoleUser)
+	moderator, _ := enum.EnumOf[Role]("moderator")
+	//assert.NotEqual(t, moderator, RoleUser)
 	assert.NotEqual(t, moderator, RoleAdmin)
 
 	assert.True(t, enum.IsValid(RoleUser))
 	assert.True(t, enum.IsValid(RoleAdmin))
-	assert.False(t, enum.IsValid(moderator))
+	// assert.False(t, enum.IsValid(moderator))
 }
 
 func Test_Enum_UndefinedEnum(t *testing.T) {
 	type Role int
 
-	moderator := enum.EnumOf[Role]("moderator")
+	moderator, _ := enum.EnumOf[Role]("moderator")
 	assert.False(t, enum.IsValid(moderator))
 	assert.False(t, enum.IsValid(Role(0)))
 }

--- a/enum_test.go
+++ b/enum_test.go
@@ -134,7 +134,6 @@ func Test_Enum_Undefined(t *testing.T) {
 
 	_, ok := enum.EnumOf[Role]("moderator")
 	assert.False(t, ok)
-	// assert.False(t, enum.IsValid(moderator))
 }
 
 func Test_Enum_UndefinedEnum(t *testing.T) {

--- a/enum_test.go
+++ b/enum_test.go
@@ -129,12 +129,11 @@ func Test_Enum_Undefined(t *testing.T) {
 		RoleAdmin = enum.New[Role]("admin")
 	)
 
-	moderator, _ := enum.EnumOf[Role]("moderator")
-	//assert.NotEqual(t, moderator, RoleUser)
-	assert.NotEqual(t, moderator, RoleAdmin)
-
 	assert.True(t, enum.IsValid(RoleUser))
 	assert.True(t, enum.IsValid(RoleAdmin))
+
+	_, ok := enum.EnumOf[Role]("moderator")
+	assert.False(t, ok)
 	// assert.False(t, enum.IsValid(moderator))
 }
 

--- a/enum_test.go
+++ b/enum_test.go
@@ -197,3 +197,18 @@ func Test_Enum_All(t *testing.T) {
 	assert.Contains(t, all, RoleUser)
 	assert.Contains(t, all, RoleAdmin)
 }
+
+func Test_Enum_Non_Int(t *testing.T) {
+	type Role byte
+
+	assert.Nil(t, enum.All[Role]())
+
+	var (
+		RoleUser  = enum.New[Role]("user")
+		RoleAdmin = enum.New[Role]("admin")
+	)
+
+	all := enum.All[Role]()
+	assert.Contains(t, all, RoleUser)
+	assert.Contains(t, all, RoleAdmin)
+}

--- a/example_test.go
+++ b/example_test.go
@@ -18,8 +18,10 @@ func ExampleNew() {
 	fmt.Println("string repr of RoleUser:", enum.StringOf(RoleUser))
 	fmt.Println("string repr of RoleAdmin:", enum.StringOf(RoleAdmin))
 
-	fmt.Println("number repr of \"user\":", enum.EnumOf[Role]("user"))
-	fmt.Println("number repr of \"admin\":", enum.EnumOf[Role]("admin"))
+	num, _ := enum.EnumOf[Role]("user")
+	fmt.Println("number repr of \"user\":", num)
+	num, _ = enum.EnumOf[Role]("admin")
+	fmt.Println("number repr of \"admin\":", num)
 
 	// Output:
 	// string repr of RoleUser: user
@@ -44,8 +46,10 @@ func ExampleMap() {
 	fmt.Println("string repr of RoleUser:", enum.StringOf(RoleUser))
 	fmt.Println("string repr of RoleAdmin:", enum.StringOf(RoleAdmin))
 
-	fmt.Println("number repr of \"user\":", enum.EnumOf[Role]("user"))
-	fmt.Println("number repr of \"admin\":", enum.EnumOf[Role]("admin"))
+	num, _ := enum.EnumOf[Role]("user")
+	fmt.Println("number repr of \"user\":", num)
+	num, _ = enum.EnumOf[Role]("admin")
+	fmt.Println("number repr of \"admin\":", num)
 
 	// Output:
 	// string repr of RoleUser: user

--- a/mtmap.go
+++ b/mtmap.go
@@ -1,0 +1,56 @@
+package enum
+
+type mtmap struct {
+	data map[any]any
+}
+
+type keyI[T any] interface {
+	getValue() T
+}
+
+func get2[V any](m *mtmap, key keyI[V]) (V, bool) {
+	var zero V
+	if m.data == nil {
+		return zero, false
+	}
+	val, exists := m.data[key]
+	if !exists {
+		return zero, false
+	}
+
+	// Type assertion can only fail if V is an interface. In that
+	// case, if the map has a `nil` in it, Go won't be able to
+	// type assert that nil into the interface value. (Note a nil
+	// *pointer* type asserts just fine, because it is still
+	// carrying a concrete type. Only nil interfaces lack any
+	// concrete type.) So if the type assertion fails, it must be
+	// a nil, here played by the zero we declared above, which
+	// must be `nil` even though the compiler can't realize that
+	// `nil` would be safe here.
+	finalVal, canAssert := val.(V)
+	if canAssert {
+		return finalVal, true
+	} else {
+		return zero, true
+	}
+}
+
+func get[V any](m *mtmap, key keyI[V]) V {
+	v, _ := get2(m, key)
+	return v
+}
+
+func set[V any](m *mtmap, key keyI[V], val V) {
+	if m.data == nil {
+		m.data = map[any]any{}
+	}
+
+	m.data[key] = val
+}
+
+type key[Key any, Value any] struct {
+	key Key
+}
+
+// this is not called, but it implements the type restriction
+func (k key[K, V]) getValue() (val V) { return }


### PR DESCRIPTION
This allows enumerations to be of any base numeric type.

The downside is that there is no general value that can be used for "invalid enumeration", so this has to change the interface of EnumOf to be (T, bool) instead of returning an invalid value. This is arguably more Go-style anyhow. Plus it is also just generally true that you can't pick an enumeration value to be a generic "you can't use this" because you don't know what users may want.

Not necessarily suggesting you take this, this was just easier than trying to describe what I meant in /r/golang.

The "mtmap.go" is stripped of docs since it is not exported, but it's an adaptation of [mtmap](https://pkg.go.dev/github.com/thejerf/mtmap). As per the README itself, it's not something you use as a library exactly, but best copied & pasted & modified as needed. In this case, the key type changed quite substantially for your use case. This allows for an `enums` map that stores everything directly, and strongly-typed. However, the API described in the docs is still effectively the same.

Some more propagation of "there isn't really an invalid value for enum" may be useful.