### PR TITLE
down go version to 1.21

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.23.0
+          go-version: 1.21.0
 
       - run: go mod tidy
 

--- a/enum.go
+++ b/enum.go
@@ -132,7 +132,7 @@ func EnumOf[T Enumable](s string) (T, bool) {
 func MustEnumOf[T Enumable](s string) T {
 	enum, ok := get2(enums, key[string, T]{s})
 	if !ok {
-		panic(fmt.Sprintf("enum %s: invalid", reflect.TypeFor[T]().Name()))
+		panic(fmt.Sprintf("enum %s: invalid", reflect.TypeOf(T(0)).Name()))
 	}
 
 	return enum
@@ -142,7 +142,7 @@ func MustEnumOf[T Enumable](s string) T {
 func StringOf[T Enumable](value T) string {
 	enum, ok := get2(enums, key[T, string]{value})
 	if !ok {
-		return fmt.Sprintf("%s::%s", reflect.TypeFor[T]().Name(), UndefinedString)
+		return fmt.Sprintf("%s::%s", reflect.TypeOf(T(0)).Name(), UndefinedString)
 	}
 	return enum
 }
@@ -152,7 +152,7 @@ func StringOf[T Enumable](value T) string {
 func MustStringOf[T Enumable](value T) string {
 	str := StringOf(value)
 	if strings.HasSuffix(str, UndefinedString) {
-		panic(fmt.Sprintf("enum %s: invalid value %v", reflect.TypeFor[T]().Name(), value))
+		panic(fmt.Sprintf("enum %s: invalid value %v", reflect.TypeOf(T(0)).Name(), value))
 	}
 
 	return str
@@ -175,7 +175,7 @@ func IsValid[T Enumable](value T) bool {
 //	data, _ := MarshalJSON(role)  // Result: []byte(`"admin"`)
 func MarshalJSON[T Enumable](value T) ([]byte, error) {
 	if !IsValid(value) {
-		return nil, fmt.Errorf("unknown %s: %v", reflect.TypeFor[T]().Name(), value)
+		return nil, fmt.Errorf("unknown %s: %v", reflect.TypeOf(T(0)).Name(), value)
 	}
 
 	return json.Marshal(StringOf(value))
@@ -198,7 +198,7 @@ func UnmarshalJSON[T Enumable](data []byte, t *T) error {
 
 	enum, valid := EnumOf[T](str)
 	if !valid {
-		return fmt.Errorf("unknown %s string: %s", reflect.TypeFor[T]().Name(), str)
+		return fmt.Errorf("unknown %s string: %s", reflect.TypeOf(T(0)).Name(), str)
 	}
 
 	*t = enum

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/xybor-x/enum
 
-go 1.23.2
-
-toolchain go1.23.4
+go 1.21
 
 require github.com/stretchr/testify v1.10.0
 


### PR DESCRIPTION
The library should use as low as possible go version to support for production projects.

Down go version from 1.23 to 1.21.

It needs go 1.21 for type assertion in mtmap.