### PR TITLE
Refactor mtmap and add mtkey for better readability

### DIFF
--- a/internal/enumable.go
+++ b/internal/enumable.go
@@ -1,0 +1,7 @@
+package internal
+
+type Enumable interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 |
+		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 |
+		~float32 | ~float64
+}

--- a/internal/mtkey/mtkey.go
+++ b/internal/mtkey/mtkey.go
@@ -1,0 +1,31 @@
+package mtkey
+
+import "github.com/xybor-x/enum/internal"
+
+type enum2String[T internal.Enumable] struct {
+	key T
+}
+
+func Enum2String[T internal.Enumable](enum T) enum2String[T] {
+	return enum2String[T]{key: enum}
+}
+
+func (enum2String[T]) InferValue() string { panic("not implemented") }
+
+type string2Enum[T internal.Enumable] struct {
+	key string
+}
+
+func String2Enum[T internal.Enumable](s string) string2Enum[T] {
+	return string2Enum[T]{key: s}
+}
+
+func (string2Enum[T]) InferValue() T { panic("not implemented") }
+
+type allEnums[T internal.Enumable] struct{}
+
+func AllEnums[T internal.Enumable]() allEnums[T] {
+	return allEnums[T]{}
+}
+
+func (allEnums[T]) InferValue() []T { panic("not implemented") }

--- a/internal/mtmap/global.go
+++ b/internal/mtmap/global.go
@@ -1,0 +1,15 @@
+package mtmap
+
+var globalmap = &MTMap{}
+
+func Get[V any](key mtKeyer[V]) (V, bool) {
+	return GetM(globalmap, key)
+}
+
+func MustGet[V any](key mtKeyer[V]) V {
+	return MustGetM(globalmap, key)
+}
+
+func Set[V any](key mtKeyer[V], v V) {
+	SetM(globalmap, key, v)
+}

--- a/internal/mtmap/mtmap.go
+++ b/internal/mtmap/mtmap.go
@@ -1,14 +1,14 @@
-package enum
+package mtmap
 
-type mtmap struct {
+type MTMap struct {
 	data map[any]any
 }
 
-type keyI[T any] interface {
-	underlyingkey() T
+type mtKeyer[V any] interface {
+	InferValue() V
 }
 
-func get2[V any](m *mtmap, key keyI[V]) (V, bool) {
+func GetM[V any](m *MTMap, key mtKeyer[V]) (V, bool) {
 	var zero V
 	if m.data == nil {
 		return zero, false
@@ -36,22 +36,15 @@ func get2[V any](m *mtmap, key keyI[V]) (V, bool) {
 	}
 }
 
-func get[V any](m *mtmap, key keyI[V]) V {
-	v, _ := get2(m, key)
+func MustGetM[V any](m *MTMap, key mtKeyer[V]) V {
+	v, _ := GetM[V](m, key)
 	return v
 }
 
-func set[V any](m *mtmap, key keyI[V], val V) {
+func SetM[V any](m *MTMap, key mtKeyer[V], val V) {
 	if m.data == nil {
 		m.data = map[any]any{}
 	}
 
 	m.data[key] = val
 }
-
-type key[K, V any] struct {
-	key K
-}
-
-// this is not called, but it implements the type asseertion.
-func (k key[K, V]) underlyingkey() (val V) { return }


### PR DESCRIPTION
**Problem**
The `mtmap` structure is currently difficult to read due to its unclear key implementation.

**Solution**
This PR refactors `mtmap` and introduces `mtkey` to improve code readability and clarity.