### PR TITLE
Introduce safe enum + serde

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Convert an `enum` to string.
 ```go
 fmt.Println("String:", enum.ToString(RoleAdmin))  // Output: "admin"
 
-// Note that you should check if enum is valid before calling ToString for
+// Note that you should check if the enum is valid before calling ToString for
 // an unsafe enum.
 fmt.Println("String:", enum.ToString(Role(42)))   // panic
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/xybor-x/enum.svg)](https://pkg.go.dev/github.com/xybor-x/enum)
 
-# Enum
+# Go Enum
 
 **Elegant and powerful enums for Go with zero code generation!**
 

--- a/internal/common/integral.go
+++ b/internal/common/integral.go
@@ -1,0 +1,6 @@
+package common
+
+type Integral interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 |
+		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64
+}

--- a/internal/common/reflect.go
+++ b/internal/common/reflect.go
@@ -1,0 +1,7 @@
+package common
+
+import "reflect"
+
+func NameOf[T any]() string {
+	return reflect.TypeOf((*T)(nil)).Elem().Name()
+}

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -1,0 +1,51 @@
+package core
+
+import (
+	"github.com/xybor-x/enum/internal/mtkey"
+	"github.com/xybor-x/enum/internal/mtmap"
+)
+
+func GetAvailableEnumValue[T any]() int64 {
+	id := int64(0)
+	for {
+		if _, ok := mtmap.Get(mtkey.Int2Enum[T](id)); !ok {
+			break
+		}
+		id++
+	}
+
+	return id
+}
+
+func MapAny[T any](num int64, value T, s string) T {
+	if s == "" {
+		panic("not allow empty string representation in enum definition")
+	}
+
+	if ok := mtmap.MustGet(mtkey.IsFinalized[T]()); ok {
+		panic("enum is finalized")
+	}
+
+	if _, ok := mtmap.Get(mtkey.Int2Enum[T](num)); ok {
+		panic("duplicate enum number is not allowed")
+	}
+
+	if _, ok := mtmap.Get(mtkey.String2Enum[T](s)); ok {
+		panic("duplicate enum string is not allowed")
+	}
+
+	if _, ok := mtmap.Get(mtkey.Enum2Int(value)); ok {
+		panic("duplicate enum is not allowed")
+	}
+
+	mtmap.Set(mtkey.Enum2String(value), s)
+	mtmap.Set(mtkey.Enum2Int(value), num)
+	mtmap.Set(mtkey.String2Enum[T](s), value)
+	mtmap.Set(mtkey.Int2Enum[T](num), value)
+
+	allVals := mtmap.MustGet(mtkey.AllEnums[T]())
+	allVals = append(allVals, value)
+	mtmap.Set(mtkey.AllEnums[T](), allVals)
+
+	return value
+}

--- a/internal/enumable.go
+++ b/internal/enumable.go
@@ -1,7 +1,0 @@
-package internal
-
-type Enumable interface {
-	~int | ~int8 | ~int16 | ~int32 | ~int64 |
-		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 |
-		~float32 | ~float64
-}

--- a/internal/mtkey/mtkey.go
+++ b/internal/mtkey/mtkey.go
@@ -1,31 +1,49 @@
 package mtkey
 
-import "github.com/xybor-x/enum/internal"
-
-type enum2String[T internal.Enumable] struct {
-	key T
-}
-
-func Enum2String[T internal.Enumable](enum T) enum2String[T] {
-	return enum2String[T]{key: enum}
-}
+type enum2String[T any] struct{ key T }
 
 func (enum2String[T]) InferValue() string { panic("not implemented") }
 
-type string2Enum[T internal.Enumable] struct {
-	key string
+func Enum2String[T any](enum T) enum2String[T] {
+	return enum2String[T]{key: enum}
 }
 
-func String2Enum[T internal.Enumable](s string) string2Enum[T] {
-	return string2Enum[T]{key: s}
+type enum2Int[T any] struct{ key T }
+
+func (enum2Int[T]) InferValue() int64 { panic("not implemented") }
+
+func Enum2Int[T any](enum T) enum2Int[T] {
+	return enum2Int[T]{key: enum}
 }
+
+type string2Enum[T any] struct{ key string }
 
 func (string2Enum[T]) InferValue() T { panic("not implemented") }
 
-type allEnums[T internal.Enumable] struct{}
+func String2Enum[T any](s string) string2Enum[T] {
+	return string2Enum[T]{key: s}
+}
 
-func AllEnums[T internal.Enumable]() allEnums[T] {
+type num2Enum[T any] struct{ key int64 }
+
+func (num2Enum[T]) InferValue() T { panic("not implemented") }
+
+func Int2Enum[T any](key int64) num2Enum[T] {
+	return num2Enum[T]{key: key}
+}
+
+type allEnums[T any] struct{}
+
+func (allEnums[T]) InferValue() []T { panic("not implemented") }
+
+func AllEnums[T any]() allEnums[T] {
 	return allEnums[T]{}
 }
 
-func (allEnums[T]) InferValue() []T { panic("not implemented") }
+type isFinalized[T any] struct{}
+
+func (isFinalized[T]) InferValue() bool { panic("not implemented") }
+
+func IsFinalized[T any]() isFinalized[T] {
+	return isFinalized[T]{}
+}

--- a/internal/mtmap/mtmap.go
+++ b/internal/mtmap/mtmap.go
@@ -37,7 +37,7 @@ func GetM[V any](m *MTMap, key mtKeyer[V]) (V, bool) {
 }
 
 func MustGetM[V any](m *MTMap, key mtKeyer[V]) V {
-	v, _ := GetM[V](m, key)
+	v, _ := GetM(m, key)
 	return v
 }
 

--- a/rich_enum.go
+++ b/rich_enum.go
@@ -10,36 +10,40 @@ import (
 // It includes various helper functions for operations like serialization,
 // deserialization, string conversion, and validation, making it easier to
 // manage and manipulate enum values across your codebase.
-type RichEnum[T any] int
+type RichEnum[dummyEnum any] int
 
-func (e RichEnum[T]) IsValid() bool {
+func (e RichEnum[dummyEnum]) IsValid() bool {
 	return IsValid(e)
 }
 
-func (e RichEnum[T]) MarshalJSON() ([]byte, error) {
+func (e RichEnum[dummyEnum]) MarshalJSON() ([]byte, error) {
 	return MarshalJSON(e)
 }
 
-func (e *RichEnum[T]) UnmarshalJSON(data []byte) error {
+func (e *RichEnum[dummyEnum]) UnmarshalJSON(data []byte) error {
 	return UnmarshalJSON(data, e)
 }
 
-func (e RichEnum[T]) Value() (driver.Value, error) {
+func (e RichEnum[dummyEnum]) Value() (driver.Value, error) {
 	return ValueSQL(e)
 }
 
-func (e *RichEnum[T]) Scan(a any) error {
+func (e *RichEnum[dummyEnum]) Scan(a any) error {
 	return ScanSQL(a, e)
 }
 
-func (e RichEnum[T]) Int() int {
-	return int(e)
+func (e RichEnum[dummyEnum]) Int() int {
+	return ToInt(e)
 }
 
-func (e RichEnum[T]) String() string {
+func (e RichEnum[dummyEnum]) String() string {
 	return ToString(e)
 }
 
-func (e RichEnum[T]) GoString() string {
+func (e RichEnum[dummyEnum]) GoString() string {
+	if !e.IsValid() {
+		return fmt.Sprintf("%d (<<undefined>>)", e)
+	}
+
 	return fmt.Sprintf("%d (%s)", e, e)
 }

--- a/safeenum/example_test.go
+++ b/safeenum/example_test.go
@@ -1,0 +1,55 @@
+package safeenum_test
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/xybor-x/enum"
+	"github.com/xybor-x/enum/safeenum"
+)
+
+func ExampleSafeEnum() {
+	// Define enum's underlying type.
+	type unsafeRole any
+
+	// Create a SafeEnum type for roles.
+	type Role = safeenum.SafeEnum[unsafeRole]
+
+	// Define specific enum values for the Role type.
+	// The second type parameter is known as the positioner. Note that each enum
+	// must have a unique positioner; no two enums can share the same positioner.
+	var (
+		RoleUser  = safeenum.New[unsafeRole, safeenum.P0]("user")
+		RoleAdmin = safeenum.New[unsafeRole, safeenum.P1]("admin")
+		_         = enum.Finalize[Role]() // Optional: ensure no new enum values can be added to Role.
+	)
+
+	// Utility functions of enum can still be used with SafeEnum.
+	fmt.Println(enum.All[Role]())                      // [user admin]
+	fmt.Println(enum.MustFromInt[Role](0) == RoleUser) // true
+
+	// Define a User struct that includes a Role field.
+	type User struct {
+		ID   int    `json:"id"`
+		Name string `json:"name"`
+
+		// Use enum.Serde due to the designation of SafeEnum, as it cannot be directly deserialized.
+		Role enum.Serde[Role] `json:"role"`
+	}
+
+	// Create a new User with the RoleAdmin and serialize it to JSON.
+	user1 := User{ID: 0, Name: "tester", Role: enum.SerdeWrap(RoleAdmin)}
+	data, _ := json.Marshal(user1) // Marshal user1 into JSON
+	fmt.Println(string(data))      // Print the JSON string representation of user1
+
+	// Unmarshal the JSON data back into a User object.
+	user2 := User{}
+	json.Unmarshal(data, &user2)   // Deserialize the JSON data into user2
+	fmt.Println(user2.Role.Enum()) // Print the role of user2, which should be "admin"
+
+	// Output:
+	// [user admin]
+	// true
+	// {"id":0,"name":"tester","role":"admin"}
+	// admin
+}

--- a/safeenum/position.go
+++ b/safeenum/position.go
@@ -1,0 +1,405 @@
+package safeenum
+
+type positioner interface {
+	position() int
+}
+
+type P0 struct{}
+
+func (P0) position() int { return 0 }
+
+type P1 struct{}
+
+func (P1) position() int { return 1 }
+
+type P2 struct{}
+
+func (P2) position() int { return 2 }
+
+type P3 struct{}
+
+func (P3) position() int { return 3 }
+
+type P4 struct{}
+
+func (P4) position() int { return 4 }
+
+type P5 struct{}
+
+func (P5) position() int { return 5 }
+
+type P6 struct{}
+
+func (P6) position() int { return 6 }
+
+type P7 struct{}
+
+func (P7) position() int { return 7 }
+
+type P8 struct{}
+
+func (P8) position() int { return 8 }
+
+type P9 struct{}
+
+func (P9) position() int { return 9 }
+
+type P10 struct{}
+
+func (P10) position() int { return 10 }
+
+type P11 struct{}
+
+func (P11) position() int { return 11 }
+
+type P12 struct{}
+
+func (P12) position() int { return 12 }
+
+type P13 struct{}
+
+func (P13) position() int { return 13 }
+
+type P14 struct{}
+
+func (P14) position() int { return 14 }
+
+type P15 struct{}
+
+func (P15) position() int { return 15 }
+
+type P16 struct{}
+
+func (P16) position() int { return 16 }
+
+type P17 struct{}
+
+func (P17) position() int { return 17 }
+
+type P18 struct{}
+
+func (P18) position() int { return 18 }
+
+type P19 struct{}
+
+func (P19) position() int { return 19 }
+
+type P20 struct{}
+
+func (P20) position() int { return 20 }
+
+type P21 struct{}
+
+func (P21) position() int { return 21 }
+
+type P22 struct{}
+
+func (P22) position() int { return 22 }
+
+type P23 struct{}
+
+func (P23) position() int { return 23 }
+
+type P24 struct{}
+
+func (P24) position() int { return 24 }
+
+type P25 struct{}
+
+func (P25) position() int { return 25 }
+
+type P26 struct{}
+
+func (P26) position() int { return 26 }
+
+type P27 struct{}
+
+func (P27) position() int { return 27 }
+
+type P28 struct{}
+
+func (P28) position() int { return 28 }
+
+type P29 struct{}
+
+func (P29) position() int { return 29 }
+
+type P30 struct{}
+
+func (P30) position() int { return 30 }
+
+type P31 struct{}
+
+func (P31) position() int { return 31 }
+
+type P32 struct{}
+
+func (P32) position() int { return 32 }
+
+type P33 struct{}
+
+func (P33) position() int { return 33 }
+
+type P34 struct{}
+
+func (P34) position() int { return 34 }
+
+type P35 struct{}
+
+func (P35) position() int { return 35 }
+
+type P36 struct{}
+
+func (P36) position() int { return 36 }
+
+type P37 struct{}
+
+func (P37) position() int { return 37 }
+
+type P38 struct{}
+
+func (P38) position() int { return 38 }
+
+type P39 struct{}
+
+func (P39) position() int { return 39 }
+
+type P40 struct{}
+
+func (P40) position() int { return 40 }
+
+type P41 struct{}
+
+func (P41) position() int { return 41 }
+
+type P42 struct{}
+
+func (P42) position() int { return 42 }
+
+type P43 struct{}
+
+func (P43) position() int { return 43 }
+
+type P44 struct{}
+
+func (P44) position() int { return 44 }
+
+type P45 struct{}
+
+func (P45) position() int { return 45 }
+
+type P46 struct{}
+
+func (P46) position() int { return 46 }
+
+type P47 struct{}
+
+func (P47) position() int { return 47 }
+
+type P48 struct{}
+
+func (P48) position() int { return 48 }
+
+type P49 struct{}
+
+func (P49) position() int { return 49 }
+
+type P50 struct{}
+
+func (P50) position() int { return 50 }
+
+type P51 struct{}
+
+func (P51) position() int { return 51 }
+
+type P52 struct{}
+
+func (P52) position() int { return 52 }
+
+type P53 struct{}
+
+func (P53) position() int { return 53 }
+
+type P54 struct{}
+
+func (P54) position() int { return 54 }
+
+type P55 struct{}
+
+func (P55) position() int { return 55 }
+
+type P56 struct{}
+
+func (P56) position() int { return 56 }
+
+type P57 struct{}
+
+func (P57) position() int { return 57 }
+
+type P58 struct{}
+
+func (P58) position() int { return 58 }
+
+type P59 struct{}
+
+func (P59) position() int { return 59 }
+
+type P60 struct{}
+
+func (P60) position() int { return 60 }
+
+type P61 struct{}
+
+func (P61) position() int { return 61 }
+
+type P62 struct{}
+
+func (P62) position() int { return 62 }
+
+type P63 struct{}
+
+func (P63) position() int { return 63 }
+
+type P64 struct{}
+
+func (P64) position() int { return 64 }
+
+type P65 struct{}
+
+func (P65) position() int { return 65 }
+
+type P66 struct{}
+
+func (P66) position() int { return 66 }
+
+type P67 struct{}
+
+func (P67) position() int { return 67 }
+
+type P68 struct{}
+
+func (P68) position() int { return 68 }
+
+type P69 struct{}
+
+func (P69) position() int { return 69 }
+
+type P70 struct{}
+
+func (P70) position() int { return 70 }
+
+type P71 struct{}
+
+func (P71) position() int { return 71 }
+
+type P72 struct{}
+
+func (P72) position() int { return 72 }
+
+type P73 struct{}
+
+func (P73) position() int { return 73 }
+
+type P74 struct{}
+
+func (P74) position() int { return 74 }
+
+type P75 struct{}
+
+func (P75) position() int { return 75 }
+
+type P76 struct{}
+
+func (P76) position() int { return 76 }
+
+type P77 struct{}
+
+func (P77) position() int { return 77 }
+
+type P78 struct{}
+
+func (P78) position() int { return 78 }
+
+type P79 struct{}
+
+func (P79) position() int { return 79 }
+
+type P80 struct{}
+
+func (P80) position() int { return 80 }
+
+type P81 struct{}
+
+func (P81) position() int { return 81 }
+
+type P82 struct{}
+
+func (P82) position() int { return 82 }
+
+type P83 struct{}
+
+func (P83) position() int { return 83 }
+
+type P84 struct{}
+
+func (P84) position() int { return 84 }
+
+type P85 struct{}
+
+func (P85) position() int { return 85 }
+
+type P86 struct{}
+
+func (P86) position() int { return 86 }
+
+type P87 struct{}
+
+func (P87) position() int { return 87 }
+
+type P88 struct{}
+
+func (P88) position() int { return 88 }
+
+type P89 struct{}
+
+func (P89) position() int { return 89 }
+
+type P90 struct{}
+
+func (P90) position() int { return 90 }
+
+type P91 struct{}
+
+func (P91) position() int { return 91 }
+
+type P92 struct{}
+
+func (P92) position() int { return 92 }
+
+type P93 struct{}
+
+func (P93) position() int { return 93 }
+
+type P94 struct{}
+
+func (P94) position() int { return 94 }
+
+type P95 struct{}
+
+func (P95) position() int { return 95 }
+
+type P96 struct{}
+
+func (P96) position() int { return 96 }
+
+type P97 struct{}
+
+func (P97) position() int { return 97 }
+
+type P98 struct{}
+
+func (P98) position() int { return 98 }
+
+type P99 struct{}
+
+func (P99) position() int { return 99 }

--- a/safeenum/safe_enum.go
+++ b/safeenum/safe_enum.go
@@ -1,0 +1,69 @@
+package safeenum
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/xybor-x/enum"
+	"github.com/xybor-x/enum/internal/core"
+)
+
+// SafeEnum defines a type-safe enum.
+//
+// The SafeEnum enforces strict type safety, ensuring that only predefined enum
+// values are allowed. It prevents the accidental creation of new enum types,
+// providing a guaranteed set of valid values.
+//
+// Note: This interface does not include deserialization capabilities. If you
+// require serialization and deserialization functionality, consider using
+// enum.SerdeWrap, which provides additional support for those operations.
+type SafeEnum[unsafeEnum any] interface {
+	fmt.Stringer
+	fmt.GoStringer
+
+	json.Marshaler
+	driver.Valuer
+
+	Int() int
+
+	safeenum() unsafeEnum
+}
+
+func New[unsafeEnum any, P positioner](s string) SafeEnum[unsafeEnum] {
+	var p P
+	return core.MapAny[SafeEnum[unsafeEnum]](int64(p.position()), safeEnum[unsafeEnum, P]{}, s)
+}
+
+type safeEnum[unsafeEnum any, P positioner] struct{}
+
+func (e safeEnum[unsafeEnum, P]) MarshalJSON() ([]byte, error) {
+	return enum.MarshalJSON[SafeEnum[unsafeEnum]](e)
+}
+
+func (e *safeEnum[unsafeEnum, P]) UnmarshalJSON([]byte) error {
+	return errors.New("not implemented")
+}
+
+func (e safeEnum[unsafeEnum, P]) Value() (driver.Value, error) {
+	return enum.ValueSQL[SafeEnum[unsafeEnum]](e)
+}
+
+func (e *safeEnum[unsafeEnum, P]) Scan(data any) error {
+	return errors.New("not implemented")
+}
+
+func (e safeEnum[unsafeEnum, P]) Int() int {
+	return enum.ToInt[SafeEnum[unsafeEnum]](e)
+}
+
+func (e safeEnum[unsafeEnum, P]) String() string {
+	return enum.ToString[SafeEnum[unsafeEnum]](e)
+}
+
+func (e safeEnum[unsafeEnum, P]) GoString() string {
+	return fmt.Sprintf("%d (%s)", e.Int(), e)
+}
+
+func (e safeEnum[unsafeEnum, P]) safeenum() unsafeEnum { panic("not implemented") }

--- a/safeenum/safe_enum_test.go
+++ b/safeenum/safe_enum_test.go
@@ -1,0 +1,86 @@
+package safeenum_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/xybor-x/enum"
+	"github.com/xybor-x/enum/safeenum"
+)
+
+type role any
+type Role = safeenum.SafeEnum[role]
+
+var (
+	RoleUser  = safeenum.New[role, safeenum.P0]("user")
+	RoleAdmin = safeenum.New[role, safeenum.P1]("admin")
+)
+
+func TestString(t *testing.T) {
+	assert.Equal(t, "user", RoleUser.String())
+	assert.Equal(t, "admin", RoleAdmin.String())
+}
+
+func TestAll(t *testing.T) {
+	assert.Equal(t, enum.All[Role](), []Role{RoleUser, RoleAdmin})
+}
+
+func TestMarshal(t *testing.T) {
+	data, err := json.Marshal(RoleUser)
+	assert.NoError(t, err)
+	assert.Equal(t, `"user"`, string(data))
+}
+
+func TestValue(t *testing.T) {
+	data, err := RoleUser.Value()
+	assert.NoError(t, err)
+	assert.Equal(t, "user", data)
+}
+
+func TestInt(t *testing.T) {
+	assert.Equal(t, 0, RoleUser.Int())
+	assert.Equal(t, 1, RoleAdmin.Int())
+}
+
+func TestGoString(t *testing.T) {
+	assert.Equal(t, "0 (user)", RoleUser.GoString())
+}
+
+func TestUnmarshal(t *testing.T) {
+	var r enum.Serde[Role]
+	err := json.Unmarshal([]byte(`"user"`), &r)
+	assert.NoError(t, err)
+	assert.Equal(t, RoleUser, r.Enum())
+}
+
+func TestScan(t *testing.T) {
+	var r enum.Serde[Role]
+
+	assert.NoError(t, r.Scan("user"))
+	assert.Equal(t, RoleUser, r.Enum())
+
+	assert.Error(t, r.Scan("nothing"))
+}
+
+func TestUnmarshalJSONStruct(t *testing.T) {
+	data := "{\"id\":1,\"role\":\"user\"}"
+
+	type User1 struct {
+		ID   int  `json:"id"`
+		Role Role `json:"role"`
+	}
+
+	var user1 User1
+	assert.ErrorContains(t, json.Unmarshal([]byte(data), &user1),
+		"json: cannot unmarshal string into Go struct field User1.role")
+
+	type User2 struct {
+		ID   int              `json:"id"`
+		Role enum.Serde[Role] `json:"role"`
+	}
+
+	var user2 User2
+	assert.NoError(t, json.Unmarshal([]byte(data), &user2))
+	assert.Equal(t, RoleUser, user2.Role.Enum())
+}

--- a/serde_wrap.go
+++ b/serde_wrap.go
@@ -1,0 +1,88 @@
+package enum
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+
+	"github.com/xybor-x/enum/internal/common"
+)
+
+// Serde provides functionality for serializing and deserializing enums
+// that cannot be directly serialized or deserialized.
+//
+// Note: This struct is intentionally non-comparable. If you need a comparable
+// version, use ComparableSerde instead.
+//
+// Why is it non-comparable?
+// The primary purpose of this struct is to handle serialization and
+// deserialization. It is not intended to replace the role or purpose of the
+// enum itself.
+type Serde[Enum any] struct {
+	ComparableSerde[Enum]
+	_ []byte // prevent comparison
+}
+
+func SerdeWrap[Enum any](enum Enum) Serde[Enum] {
+	return Serde[Enum]{ComparableSerde: ComparableSerdeWrap(enum)}
+}
+
+// ComparableSerde facilitates the serialization and deserialization of enums
+// that cannot be directly serialized or deserialized.
+//
+// It is similar to Store but comparable.
+type ComparableSerde[Enum any] struct {
+	enum Enum
+}
+
+func ComparableSerdeWrap[Enum any](enum Enum) ComparableSerde[Enum] {
+	return ComparableSerde[Enum]{enum: enum}
+}
+
+// Enum returns the inner enum.
+func (e ComparableSerde[Enum]) Enum() Enum {
+	return e.enum
+}
+
+func (e ComparableSerde[Enum]) MarshalJSON() ([]byte, error) {
+	return MarshalJSON(e.enum)
+}
+
+func (e *ComparableSerde[Enum]) UnmarshalJSON(data []byte) error {
+	var str string
+	if err := json.Unmarshal(data, &str); err != nil {
+		return err
+	}
+
+	enum, ok := FromString[Enum](str)
+	if !ok {
+		return fmt.Errorf("enum %s: invalid string %s", common.NameOf[Enum](), str)
+	}
+
+	e.enum = enum
+	return nil
+}
+
+func (e ComparableSerde[Enum]) Value() (driver.Value, error) {
+	return ValueSQL(e.enum)
+}
+
+func (e *ComparableSerde[Enum]) Scan(a any) error {
+	var data string
+	switch t := a.(type) {
+	case string:
+		data = t
+	case []byte:
+		data = string(t)
+	default:
+		return fmt.Errorf("not support type %T", a)
+	}
+
+	enum, ok := FromString[Enum](data)
+	if !ok {
+		return fmt.Errorf("enum %s: invalid string %s", common.NameOf[Enum](), a)
+	}
+
+	e.enum = enum
+	return nil
+}

--- a/serde_wrap_test.go
+++ b/serde_wrap_test.go
@@ -1,0 +1,46 @@
+package enum_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/xybor-x/enum"
+)
+
+func TestSerdeInt(t *testing.T) {
+	type Role int
+
+	var (
+		RoleUser = enum.New[Role]("user")
+	)
+
+	nonSerdeJSON := `{"id":1,"role":0}`
+	serdeJSON := `{"id":1,"role":"user"}`
+
+	type NonSerdeUser struct {
+		ID   int  `json:"id"`
+		Role Role `json:"role"`
+	}
+
+	user1 := NonSerdeUser{ID: 1, Role: RoleUser}
+	data, err := json.Marshal(user1)
+	assert.NoError(t, err)
+	assert.Equal(t, nonSerdeJSON, string(data))
+
+	type SerdeUser struct {
+		ID   int              `json:"id"`
+		Role enum.Serde[Role] `json:"role"`
+	}
+
+	user2 := SerdeUser{ID: 1, Role: enum.SerdeWrap(RoleUser)}
+	data, err = json.Marshal(user2)
+	assert.NoError(t, err)
+	assert.Equal(t, serdeJSON, string(data))
+
+	user3 := SerdeUser{}
+	assert.ErrorContains(t, json.Unmarshal([]byte(nonSerdeJSON), &user3), "json: cannot unmarshal")
+
+	assert.NoError(t, json.Unmarshal([]byte(serdeJSON), &user3))
+	assert.Equal(t, RoleUser, user3.Role.Enum())
+}


### PR DESCRIPTION
**Problem**
- Int enum has a problem: it's easy to create an invalid enum by accident. For example:
```go
type role any
type Role = enum.RichEnum[role]

const (
    RoleUser = iota
    RoleAdmin
)

var (
    _ = enum.Map(RoleUser, "user")
    _ = enum.Map(RoleAdmin, "admin")
)

var invalidRole = Role(42)
```

**Solution**
`SafeEnum`: provides a type-safe enum. However, it doesn't support deserialization natively. This is the reason why `Serde` is created.
`Serde`: A wrapper provides functionality for serializing and deserializing enums that cannot be directly serialized or deserialized.

**Example**
```go
// Define enum's underlying type.
type unsafeRole any

// Create a SafeEnum type for roles.
type Role = safeenum.SafeEnum[unsafeRole]

// Define specific enum values for the Role type.
// The second type parameter is known as the positioner. Note that each enum
// must have a unique positioner; no two enums can share the same positioner.
var (
    RoleUser  = safeenum.New[unsafeRole, safeenum.P0]("user")
    RoleAdmin = safeenum.New[unsafeRole, safeenum.P1]("admin")
    _         = enum.Finalize[Role]() // Optional: ensure no new enum values can be added to Role.
)

type User struct {
    ID   int    `json:"id"`
    Name string `json:"name"`
    
    // Use enum.Serde due to the designation of SafeEnum, as it cannot be directly deserialized.
    Role enum.Serde[Role] `json:"role"`
}
```