### PR TITLE
support float + resolve overflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,12 +187,12 @@ if ok {
 }
 ```
 
-### FromInt
+### FromNumber
 
-`FromInt` returns the corresponding `enum` for a given `int` representation, and whether it is valid.
+`FromNumber` returns the corresponding `enum` for a given numeric representation, and whether it is valid.
 
 ```go
-role, ok := enum.FromInt[Role](42)
+role, ok := enum.FromNumber[Role](42)
 if ok {
     fmt.Println(role)
 } else {
@@ -217,15 +217,6 @@ fmt.Println(enum.IsValid(Role(42)))  // false
 ```go
 fmt.Println(enum.ToString(RoleAdmin))  // Output: "admin"
 fmt.Println(enum.ToString(Role(42)))   // Output: "<nil>"
-```
-
-### ToInt
-
-`ToInt` converts an `enum` to `int`.  It returns the smallest number of `int` for invalid enums.
-
-```go
-fmt.Println(enum.ToInt(RoleAdmin))  // Output: 1
-fmt.Println(enum.ToInt(Role(42)))   // Output: -2147483648
 ```
 
 ### All

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -1,14 +1,18 @@
 package core
 
 import (
+	"math"
+
 	"github.com/xybor-x/enum/internal/mtkey"
 	"github.com/xybor-x/enum/internal/mtmap"
+	"github.com/xybor-x/enum/internal/xmath"
+	"github.com/xybor-x/enum/internal/xreflect"
 )
 
 func GetAvailableEnumValue[T any]() int64 {
 	id := int64(0)
 	for {
-		if _, ok := mtmap.Get(mtkey.Int2Enum[T](id)); !ok {
+		if _, ok := mtmap.Get(mtkey.Number2Enum[int64, T](id)); !ok {
 			break
 		}
 		id++
@@ -18,7 +22,7 @@ func GetAvailableEnumValue[T any]() int64 {
 }
 
 // MapAny map the enum value to the enum system.
-func MapAny[Enum any](num int64, value Enum, s string) Enum {
+func MapAny[N xreflect.Number, Enum any](id N, enum Enum, s string) Enum {
 	if s == "" {
 		panic("not allow empty string representation in enum definition")
 	}
@@ -31,7 +35,7 @@ func MapAny[Enum any](num int64, value Enum, s string) Enum {
 		panic("enum is finalized")
 	}
 
-	if _, ok := mtmap.Get(mtkey.Int2Enum[Enum](num)); ok {
+	if _, ok := mtmap.Get(mtkey.Number2Enum[N, Enum](id)); ok {
 		panic("duplicate enum number is not allowed")
 	}
 
@@ -39,18 +43,67 @@ func MapAny[Enum any](num int64, value Enum, s string) Enum {
 		panic("duplicate enum string is not allowed")
 	}
 
-	if _, ok := mtmap.Get(mtkey.Enum2Int(value)); ok {
+	if _, ok := mtmap.Get(mtkey.Enum2Number[Enum, N](enum)); ok {
 		panic("duplicate enum is not allowed")
 	}
 
-	mtmap.Set(mtkey.Enum2String(value), s)
-	mtmap.Set(mtkey.Enum2Int(value), num)
-	mtmap.Set(mtkey.String2Enum[Enum](s), value)
-	mtmap.Set(mtkey.Int2Enum[Enum](num), value)
+	mtmap.Set(mtkey.Enum2String(enum), s)
+	mtmap.Set(mtkey.String2Enum[Enum](s), enum)
+	mapnumber(enum, id)
 
 	allVals := mtmap.MustGet(mtkey.AllEnums[Enum]())
-	allVals = append(allVals, value)
+	allVals = append(allVals, enum)
 	mtmap.Set(mtkey.AllEnums[Enum](), allVals)
 
-	return value
+	return enum
+}
+
+func mapnumber[Enum any, N xreflect.Number](enum Enum, n N) {
+	// Only map the enum to integer if the enum is represented by integer
+	// values, where the integer corresponds to the actual numeric value,
+	// regardless of the underlying type.
+	mapInteger := true
+	if xreflect.IsFloat32[N]() {
+		mapInteger = xreflect.Convert[float32](n) == xmath.Trunc32(xreflect.Convert[float32](n))
+	} else if xreflect.IsFloat64[N]() {
+		mapInteger = xreflect.Convert[float64](n) == math.Trunc(xreflect.Convert[float64](n))
+	}
+
+	if mapInteger {
+		// Map enum to all signed integers.
+		mtmap.Set(mtkey.Enum2Number[Enum, int](enum), xreflect.Convert[int](n))
+		mtmap.Set(mtkey.Enum2Number[Enum, int8](enum), xreflect.Convert[int8](n))
+		mtmap.Set(mtkey.Enum2Number[Enum, int16](enum), xreflect.Convert[int16](n))
+		mtmap.Set(mtkey.Enum2Number[Enum, int32](enum), xreflect.Convert[int32](n))
+		mtmap.Set(mtkey.Enum2Number[Enum, int64](enum), xreflect.Convert[int64](n))
+
+		// Map enum to all unsigned integers.
+		mtmap.Set(mtkey.Enum2Number[Enum, uint](enum), xreflect.Convert[uint](n))
+		mtmap.Set(mtkey.Enum2Number[Enum, uint8](enum), xreflect.Convert[uint8](n))
+		mtmap.Set(mtkey.Enum2Number[Enum, uint16](enum), xreflect.Convert[uint16](n))
+		mtmap.Set(mtkey.Enum2Number[Enum, uint32](enum), xreflect.Convert[uint32](n))
+		mtmap.Set(mtkey.Enum2Number[Enum, uint64](enum), xreflect.Convert[uint64](n))
+
+		// Map all signed integers to enum.
+		mtmap.Set(mtkey.Number2Enum[int, Enum](xreflect.Convert[int](n)), enum)
+		mtmap.Set(mtkey.Number2Enum[int8, Enum](xreflect.Convert[int8](n)), enum)
+		mtmap.Set(mtkey.Number2Enum[int16, Enum](xreflect.Convert[int16](n)), enum)
+		mtmap.Set(mtkey.Number2Enum[int32, Enum](xreflect.Convert[int32](n)), enum)
+		mtmap.Set(mtkey.Number2Enum[int64, Enum](xreflect.Convert[int64](n)), enum)
+
+		// Map all unsigned integers to enum.
+		mtmap.Set(mtkey.Number2Enum[uint, Enum](xreflect.Convert[uint](n)), enum)
+		mtmap.Set(mtkey.Number2Enum[uint8, Enum](xreflect.Convert[uint8](n)), enum)
+		mtmap.Set(mtkey.Number2Enum[uint16, Enum](xreflect.Convert[uint16](n)), enum)
+		mtmap.Set(mtkey.Number2Enum[uint32, Enum](xreflect.Convert[uint32](n)), enum)
+		mtmap.Set(mtkey.Number2Enum[uint64, Enum](xreflect.Convert[uint64](n)), enum)
+	}
+
+	// Map enum to all floats.
+	mtmap.Set(mtkey.Enum2Number[Enum, float32](enum), xreflect.Convert[float32](n))
+	mtmap.Set(mtkey.Enum2Number[Enum, float64](enum), xreflect.Convert[float64](n))
+
+	// Map all floats to enum.
+	mtmap.Set(mtkey.Number2Enum[float32, Enum](xreflect.Convert[float32](n)), enum)
+	mtmap.Set(mtkey.Number2Enum[float64, Enum](xreflect.Convert[float64](n)), enum)
 }

--- a/internal/mtkey/mtkey.go
+++ b/internal/mtkey/mtkey.go
@@ -1,5 +1,7 @@
 package mtkey
 
+import "github.com/xybor-x/enum/internal/xreflect"
+
 type enum2String[T any] struct{ key T }
 
 func (enum2String[T]) InferValue() string { panic("not implemented") }
@@ -8,12 +10,12 @@ func Enum2String[T any](enum T) enum2String[T] {
 	return enum2String[T]{key: enum}
 }
 
-type enum2Int[T any] struct{ key T }
+type enum2Number[T any, N xreflect.Number] struct{ key T }
 
-func (enum2Int[T]) InferValue() int64 { panic("not implemented") }
+func (enum2Number[T, N]) InferValue() N { panic("not implemented") }
 
-func Enum2Int[T any](enum T) enum2Int[T] {
-	return enum2Int[T]{key: enum}
+func Enum2Number[T any, N xreflect.Number](enum T) enum2Number[T, N] {
+	return enum2Number[T, N]{key: enum}
 }
 
 type string2Enum[T any] struct{ key string }
@@ -24,12 +26,12 @@ func String2Enum[T any](s string) string2Enum[T] {
 	return string2Enum[T]{key: s}
 }
 
-type num2Enum[T any] struct{ key int64 }
+type number2Enum[T any] struct{ key any }
 
-func (num2Enum[T]) InferValue() T { panic("not implemented") }
+func (number2Enum[T]) InferValue() T { panic("not implemented") }
 
-func Int2Enum[T any](key int64) num2Enum[T] {
-	return num2Enum[T]{key: key}
+func Number2Enum[N xreflect.Number, T any](key N) number2Enum[T] {
+	return number2Enum[T]{key: key}
 }
 
 type allEnums[T any] struct{}

--- a/internal/xreflect/reflect.go
+++ b/internal/xreflect/reflect.go
@@ -5,6 +5,12 @@ import (
 	"slices"
 )
 
+type Number interface {
+	int | int8 | int16 | int32 | int64 |
+		uint | uint8 | uint16 | uint32 | uint64 |
+		float32 | float64
+}
+
 var (
 	intKinds  = []reflect.Kind{reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64}
 	uintKinds = []reflect.Kind{reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64}
@@ -23,6 +29,26 @@ func IsUnsignedInt[T any]() bool {
 // IsInt returns true if the value is one of any integer types.
 func IsInt[T any]() bool {
 	return IsSignedInt[T]() || IsUnsignedInt[T]()
+}
+
+// IsFloat32 returns true if the value is a float32.
+func IsFloat32[T any]() bool {
+	return reflect.TypeOf((*T)(nil)).Elem().Kind() == reflect.Float32
+}
+
+// IsFloat64 returns true if the value is a float64.
+func IsFloat64[T any]() bool {
+	return reflect.TypeOf((*T)(nil)).Elem().Kind() == reflect.Float64
+}
+
+// IsFloat returns true if the value is a float.
+func IsFloat[T any]() bool {
+	return IsFloat32[T]() || IsFloat64[T]()
+}
+
+// IsNumber returns true if the value is a number.
+func IsNumber[T any]() bool {
+	return IsFloat[T]() || IsInt[T]()
 }
 
 // IsString returns true if the value is a string.

--- a/safe_enum.go
+++ b/safe_enum.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"github.com/xybor-x/enum/internal/core"
+	"github.com/xybor-x/enum/internal/mtkey"
+	"github.com/xybor-x/enum/internal/mtmap"
 )
 
 // SafeEnum defines a strong type-safe enum. Like WrapEnum, it provides a set
@@ -39,7 +41,7 @@ func (e *SafeEnum[underlyingEnum]) Scan(a any) error {
 }
 
 func (e SafeEnum[underlyingEnum]) Int() int {
-	return ToInt(e)
+	return mtmap.MustGet(mtkey.Enum2Number[SafeEnum[underlyingEnum], int](e))
 }
 
 func (e SafeEnum[underlyingEnum]) String() string {

--- a/testing/enum_test.go
+++ b/testing/enum_test.go
@@ -285,7 +285,7 @@ func TestEnumAll(t *testing.T) {
 	assert.Contains(t, all, RoleAdmin)
 }
 
-func TestEnumNonIntEnum(t *testing.T) {
+func TestEnumByte(t *testing.T) {
 	type Role byte
 
 	assert.Nil(t, enum.All[Role]())
@@ -295,9 +295,127 @@ func TestEnumNonIntEnum(t *testing.T) {
 		RoleAdmin = enum.New[Role]("admin")
 	)
 
-	all := enum.All[Role]()
-	assert.Contains(t, all, RoleUser)
-	assert.Contains(t, all, RoleAdmin)
+	assert.Equal(t, []Role{RoleUser, RoleAdmin}, enum.All[Role]())
+}
+
+func TestEnumFloat32(t *testing.T) {
+	type Role float32
+
+	assert.Nil(t, enum.All[Role]())
+
+	var (
+		RoleUser  = enum.New[Role]("user")
+		RoleAdmin = enum.New[Role]("admin")
+	)
+
+	assert.Equal(t, []Role{RoleUser, RoleAdmin}, enum.All[Role]())
+}
+
+func TestEnumFloat32Map(t *testing.T) {
+	type Role float32
+
+	const (
+		RoleUser  Role = 1.13
+		RoleAdmin Role = 3.14
+	)
+
+	var (
+		_ = enum.Map(RoleUser, "user")
+		_ = enum.Map(RoleAdmin, "admin")
+	)
+
+	role, ok := enum.FromNumber[Role](float32(1.13))
+	assert.True(t, ok)
+	assert.Equal(t, RoleUser, role)
+
+	role, ok = enum.FromNumber[Role](float32(3.14))
+	assert.True(t, ok)
+	assert.Equal(t, RoleAdmin, role)
+}
+
+func TestEnumFloat64Map(t *testing.T) {
+	type Role float64
+
+	const (
+		RoleUser  Role = 1.13
+		RoleAdmin Role = 3.14
+	)
+
+	var (
+		_ = enum.Map(RoleUser, "user")
+		_ = enum.Map(RoleAdmin, "admin")
+	)
+
+	role, ok := enum.FromNumber[Role](float64(1.13))
+	assert.True(t, ok)
+	assert.Equal(t, RoleUser, role)
+
+	role, ok = enum.FromNumber[Role](float64(3.14))
+	assert.True(t, ok)
+	assert.Equal(t, RoleAdmin, role)
+}
+
+func TestEnumFloat32LikeInt(t *testing.T) {
+	type Role float32
+
+	assert.Nil(t, enum.All[Role]())
+
+	var (
+		RoleUser  = enum.New[Role]("user")
+		RoleAdmin = enum.New[Role]("admin")
+	)
+
+	assert.Equal(t, []Role{RoleUser, RoleAdmin}, enum.All[Role]())
+
+	role, ok := enum.FromNumber[Role](0)
+	assert.True(t, ok)
+	assert.Equal(t, RoleUser, role)
+
+	role, ok = enum.FromNumber[Role](1)
+	assert.True(t, ok)
+	assert.Equal(t, RoleAdmin, role)
+}
+
+func TestEnumFloat64LikeInt(t *testing.T) {
+	type Role float32
+
+	assert.Nil(t, enum.All[Role]())
+
+	var (
+		RoleUser  = enum.New[Role]("user")
+		RoleAdmin = enum.New[Role]("admin")
+	)
+
+	assert.Equal(t, []Role{RoleUser, RoleAdmin}, enum.All[Role]())
+
+	role, ok := enum.FromNumber[Role](0)
+	assert.True(t, ok)
+	assert.Equal(t, RoleUser, role)
+
+	role, ok = enum.FromNumber[Role](1)
+	assert.True(t, ok)
+	assert.Equal(t, RoleAdmin, role)
+}
+
+func TestEnumIntFromFloat64(t *testing.T) {
+	type Role int
+
+	assert.Nil(t, enum.All[Role]())
+
+	var (
+		RoleUser  = enum.New[Role]("user")
+		RoleAdmin = enum.New[Role]("admin")
+	)
+
+	assert.Equal(t, []Role{RoleUser, RoleAdmin}, enum.All[Role]())
+
+	role, ok := enum.FromNumber[Role](float64(0))
+	assert.True(t, ok)
+	assert.Equal(t, RoleUser, role)
+
+	role, ok = enum.FromNumber[Role](float64(1))
+	assert.True(t, ok)
+	assert.Equal(t, RoleAdmin, role)
 }
 
 func TestEnumValueSQL(t *testing.T) {

--- a/wrap_enum.go
+++ b/wrap_enum.go
@@ -6,10 +6,12 @@ import (
 	"strconv"
 
 	"github.com/xybor-x/enum/internal/core"
+	"github.com/xybor-x/enum/internal/mtkey"
+	"github.com/xybor-x/enum/internal/mtmap"
 )
 
 // WrapEnum provides a set of built-in methods to simplify working with enums.
-type WrapEnum[underlyingEnum any] int
+type WrapEnum[underlyingEnum any] int64
 
 func (e WrapEnum[underlyingEnum]) IsValid() bool {
 	return IsValid(e)
@@ -32,7 +34,7 @@ func (e *WrapEnum[underlyingEnum]) Scan(a any) error {
 }
 
 func (e WrapEnum[underlyingEnum]) Int() int {
-	return ToInt(e)
+	return mtmap.MustGet(mtkey.Enum2Number[WrapEnum[underlyingEnum], int](e))
 }
 
 func (e WrapEnum[underlyingEnum]) String() string {


### PR DESCRIPTION
Primitive type enum now support for float32, float64. And resolve completely the overflow problem without the need of panic.

DEPRECATE:
- FromInt
- MustFromInt
- ToInt

Add:
- FromNumber
- MustFromNumber